### PR TITLE
Fix logger initialization in AnalysisController

### DIFF
--- a/src/main/java/com/meeran/newsanalyzerapi/controller/AnalysisController.java
+++ b/src/main/java/com/meeran/newsanalyzerapi/controller/AnalysisController.java
@@ -17,7 +17,7 @@ import com.meeran.newsanalyzerapi.service.NewsService;
 @RestController
 @RequestMapping("/api/v1/analyze")
 public class AnalysisController {
-    private static final Logger log = LoggerFactory.getLogger(AnalysisService.class);
+    private static final Logger log = LoggerFactory.getLogger(AnalysisController.class);
 
     private final NewsService newsService;
     private final AnalysisService analysisService;


### PR DESCRIPTION
## Summary
- use AnalysisController class when initializing logger

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.meeran:news-analyzer-api)*

------
https://chatgpt.com/codex/tasks/task_e_688c305b6c04832d8b1cfacf44429b6e