### PR TITLE
Add shared RestTemplate configuration

### DIFF
--- a/src/main/java/com/meeran/newsanalyzerapi/config/RestTemplateConfig.java
+++ b/src/main/java/com/meeran/newsanalyzerapi/config/RestTemplateConfig.java
@@ -1,0 +1,20 @@
+package com.meeran.newsanalyzerapi.config;
+
+import java.time.Duration;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+            .setConnectTimeout(Duration.ofSeconds(5))
+            .setReadTimeout(Duration.ofSeconds(5))
+            .build();
+    }
+}

--- a/src/main/java/com/meeran/newsanalyzerapi/service/AnalysisService.java
+++ b/src/main/java/com/meeran/newsanalyzerapi/service/AnalysisService.java
@@ -24,8 +24,12 @@ import com.meeran.newsanalyzerapi.dto.GeminiDto;
 @Service
 public class AnalysisService {
     private static final Logger logger = LoggerFactory.getLogger(AnalysisService.class);
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AnalysisService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
 
     // --- Primary Provider Config ---
     @Value("${llm.primary.api.key}")

--- a/src/main/java/com/meeran/newsanalyzerapi/service/NewsService.java
+++ b/src/main/java/com/meeran/newsanalyzerapi/service/NewsService.java
@@ -22,8 +22,12 @@ public class NewsService {
     @Value("${news.api.key}")
     private String apiKey;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
     private static final String NEWS_API_URL = "https://newsapi.org/v2/everything";
+
+    public NewsService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
     
     public NewsApiResponse fetchArticlesForTopic(String topic) {
         // Get today's date and the date for 7 days ago


### PR DESCRIPTION
## Summary
- configure a `RestTemplate` bean with 5s connect/read timeouts
- inject the shared `RestTemplate` into `AnalysisService` and `NewsService`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688c384e2560832d957aeb75aef5074a