### PR TITLE
Encode URI components in NewsService

### DIFF
--- a/src/main/java/com/meeran/newsanalyzerapi/service/NewsService.java
+++ b/src/main/java/com/meeran/newsanalyzerapi/service/NewsService.java
@@ -43,8 +43,8 @@ public class NewsService {
             .queryParam("language", "en")
             .queryParam("pageSize", 20);
 
-        URI sanitizedUri = builder.build(true).toUri();
-        URI uri = builder.queryParam("apiKey", apiKey).build(true).toUri();
+        URI sanitizedUri = builder.cloneBuilder().build().encode().toUri();
+        URI uri = builder.cloneBuilder().queryParam("apiKey", apiKey).build().encode().toUri();
 
         logger.info("Fetching news from URL: {}", sanitizedUri);
 

--- a/src/test/java/com/meeran/newsanalyzerapi/service/NewsServiceTest.java
+++ b/src/test/java/com/meeran/newsanalyzerapi/service/NewsServiceTest.java
@@ -1,0 +1,56 @@
+package com.meeran.newsanalyzerapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import com.meeran.newsanalyzerapi.dto.NewsApiResponse;
+
+class NewsServiceTest {
+
+    @Test
+    void fetchArticlesForTopic_encodesTopicWithSpaces() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        NewsService service = new NewsService(restTemplate);
+        ReflectionTestUtils.setField(service, "apiKey", "test-key");
+
+        when(restTemplate.getForObject(any(URI.class), eq(NewsApiResponse.class))).thenReturn(new NewsApiResponse());
+
+        service.fetchArticlesForTopic("climate change");
+
+        ArgumentCaptor<URI> captor = ArgumentCaptor.forClass(URI.class);
+        verify(restTemplate).getForObject(captor.capture(), eq(NewsApiResponse.class));
+        URI calledUri = captor.getValue();
+
+        assertTrue(calledUri.toString().contains("q=climate%20change"));
+        assertTrue(calledUri.toString().contains("apiKey=test-key"));
+    }
+
+    @Test
+    void fetchArticlesForTopic_encodesSpecialCharacters() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        NewsService service = new NewsService(restTemplate);
+        ReflectionTestUtils.setField(service, "apiKey", "test-key");
+
+        when(restTemplate.getForObject(any(URI.class), eq(NewsApiResponse.class))).thenReturn(new NewsApiResponse());
+
+        service.fetchArticlesForTopic("c# & kotlin");
+
+        ArgumentCaptor<URI> captor = ArgumentCaptor.forClass(URI.class);
+        verify(restTemplate).getForObject(captor.capture(), eq(NewsApiResponse.class));
+        URI calledUri = captor.getValue();
+
+        String uri = calledUri.toString();
+        assertTrue(uri.contains("q=c%23%20%26%20kotlin"));
+    }
+}


### PR DESCRIPTION
## Summary
- encode query parameters when building News API URIs to support spaces and special characters
- add unit tests verifying encoded URIs for topics with spaces and special characters

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.meeran:news-analyzer-api: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d9cc407e0832da16b3d57761945d9