### PR TITLE
Configure RestTemplate timeouts for faster failure

### DIFF
--- a/src/main/java/com/meeran/newsanalyzerapi/config/RestTemplateConfig.java
+++ b/src/main/java/com/meeran/newsanalyzerapi/config/RestTemplateConfig.java
@@ -1,5 +1,7 @@
 package com.meeran.newsanalyzerapi.config;
 
+import java.time.Duration;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -10,7 +12,9 @@ public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        // Configure the RestTemplate to use the Apache HttpClient 5 request factory
-        return new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(5));
+        factory.setReadTimeout(Duration.ofSeconds(10));
+        return new RestTemplate(factory);
     }
 }


### PR DESCRIPTION
## Summary
- Configure RestTemplate bean with HttpComponentsClientHttpRequestFactory specifying 5s connect and 10s read timeouts

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven Central)*
- `mvn -q spring-boot:run` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_688f0802e264832d9a893a0049bb7d8b